### PR TITLE
refactor: use minimal docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /ping-server
 
-FROM golang:1.20 AS run-stage
+FROM gcr.io/distroless/base-debian11 AS run-stage
 
 WORKDIR /run
 


### PR DESCRIPTION
By restricting the capabilities of the runtime docker image we reduce the chances of hidden dependencies at runtime.

This commit is simply applying
[this](https://github.com/nlnwa/go_container/commit/5650d783636101bcc04a292b8f93a71ba7645d67) commit to the current repository.