### PR TITLE
feat: add common arguments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"hermetic/cmd/send"
 	"hermetic/cmd/verify"
+	"hermetic/internal/common_flags"
 
 	"github.com/spf13/cobra"
 )
@@ -12,7 +13,8 @@ func NewRootCommand() *cobra.Command {
 		Use:   "hermetic",
 		Short: "hermetic - sends and verifies data for digital storage",
 	}
-	rootCommand.PersistentFlags().StringSlice("kafka-endpoints", []string{}, "list of kafka endpoints")
+	rootCommand.PersistentFlags().StringSliceVar(&common_flags.KafkaEndpoints, "kafka-endpoints", []string{}, "list of kafka endpoints")
+	rootCommand.PersistentFlags().StringVar(&common_flags.TeamsWebhookNotificationUrl, "teams-webhook-notification-url", "", "url to teams webhook for notifications")
 	rootCommand.AddCommand(send.NewCommand())
 	rootCommand.AddCommand(verify.NewCommand())
 	return rootCommand

--- a/internal/common_flags/common_flags.go
+++ b/internal/common_flags/common_flags.go
@@ -1,0 +1,6 @@
+package common_flags
+
+var (
+	KafkaEndpoints              []string
+	TeamsWebhookNotificationUrl string
+)


### PR DESCRIPTION
This commit adds `--teams-webhook-notification-url` as a top-level argument and also adds parsing of this flag and the existing `--kafka-endpoints` argument.

The argument names have also been de-duplicated.

Both will be used by the `verification` and `transfer` implementations in later commits.