### PR TITLE
feat: avoid resending same messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module hermetic
 go 1.20
 
 require (
+	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/google/uuid v1.4.0
 	github.com/segmentio/kafka-go v0.4.44
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
+github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/send/send.go
+++ b/internal/send/send.go
@@ -3,10 +3,13 @@ package sendImplementation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
+	"github.com/allegro/bigcache/v3"
 	"github.com/google/uuid"
 	"github.com/segmentio/kafka-go"
 )
@@ -24,6 +27,115 @@ type sender struct {
 	writer *kafka.Writer
 }
 
+type messageReader struct {
+	reader *kafka.Reader
+}
+
+type offsets struct {
+	first int64
+	last  int64
+}
+
+func getFirstAndLastOffsets(kafkaEndpoints []string, transferTopicName string) (offsets, error) {
+	conn, err := net.Dial("tcp", kafkaEndpoints[0])
+	if err != nil {
+		return offsets{}, fmt.Errorf("failed to dial tcp, original error: '%w'", err)
+	}
+	kafkaConn := kafka.NewConn(conn, transferTopicName, 0)
+	partitions, err := kafkaConn.ReadPartitions(transferTopicName)
+	if err != nil {
+		return offsets{}, fmt.Errorf("failed to read partitions, original error: '%w'", err)
+	}
+	if len(partitions) != 1 {
+		return offsets{}, fmt.Errorf("expected exactly 1 partition, got '%d'", len(partitions))
+	}
+	connLeader, err := net.Dial("tcp", fmt.Sprintf("%s:%d", partitions[0].Leader.Host, partitions[0].Leader.Port))
+	if err != nil {
+		return offsets{}, fmt.Errorf("failed to dial tcp, original error: '%w'", err)
+	}
+	kafkaLeaderConn := kafka.NewConn(connLeader, transferTopicName, 0)
+
+	firstOffset, lastOffset, err := kafkaLeaderConn.ReadOffsets()
+	if err != nil {
+		return offsets{}, fmt.Errorf("failed to read offsets, original error: '%w'", err)
+	}
+	return offsets{first: firstOffset, last: lastOffset}, nil
+}
+
+func (reader *messageReader) readMessageWithTimeout(timeout time.Duration) (message kafka.Message, err error) {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return reader.reader.ReadMessage(ctxTimeout)
+}
+
+func readLatestMessages(kafkaEndpoints []string, transferTopicName string) ([]TransferSubmissionInformationPackage, error) {
+	messageReader := messageReader{
+		reader: kafka.NewReader(kafka.ReaderConfig{
+			Brokers: kafkaEndpoints,
+			Topic:   transferTopicName,
+		}),
+	}
+
+	defer messageReader.reader.Close()
+
+	offsets, err := getFirstAndLastOffsets(kafkaEndpoints, transferTopicName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get first and last offset, original error: '%w'", err)
+	}
+	readTimeout := 10 * time.Second
+
+	var messages []TransferSubmissionInformationPackage
+
+	for offsetToReadFrom := offsets.first; offsetToReadFrom < offsets.last; offsetToReadFrom++ {
+		fmt.Printf("Reading message at offset '%d'\n", offsetToReadFrom)
+		err := messageReader.reader.SetOffset(offsetToReadFrom)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set offset '%d', original error: '%w'", offsetToReadFrom, err)
+		}
+
+		message, err := messageReader.readMessageWithTimeout(readTimeout)
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Printf("Could not read message at offset '%d', read timeout '%s' exceeded, skipping offset\n", offsetToReadFrom, readTimeout)
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read message at offset '%d', original error: '%w'", offsetToReadFrom, err)
+		}
+		if message.Value == nil {
+			fmt.Printf("Message at offset '%d' is nil, skipping offset\n", offsetToReadFrom)
+			continue
+		}
+		var transferSubmissionInformationPackage TransferSubmissionInformationPackage
+
+		err = json.Unmarshal(message.Value, &transferSubmissionInformationPackage)
+		if err != nil {
+			syntaxError := new(json.SyntaxError)
+			if errors.As(err, &syntaxError) {
+				fmt.Printf("Could not read message at offset '%d', syntax error in message, skipping offset\n", offsetToReadFrom)
+				continue
+			}
+			return nil, fmt.Errorf("failed to unmarshal json, original error: '%w'", err)
+		}
+		messages = append(messages, transferSubmissionInformationPackage)
+
+	}
+
+	return messages, nil
+}
+
+func webArchiveRelevantMessages(messages []TransferSubmissionInformationPackage) ([]TransferSubmissionInformationPackage, error) {
+	var relevantMessages []TransferSubmissionInformationPackage
+	for _, message := range messages {
+		if message.ContentCategory == "nettarkiv" {
+			if message.ContentType != "warc" {
+				return nil, fmt.Errorf("found content type '%s' in message '%+v', expected 'warc'", message.ContentType, message)
+			}
+			relevantMessages = append(relevantMessages, message)
+		}
+	}
+	return relevantMessages, nil
+}
+
 func PrepareAndSendSubmissionInformationPackage(kafkaEndpoints []string, transferTopicName string, rootPath string) error {
 	sender := sender{
 		writer: &kafka.Writer{
@@ -35,32 +147,74 @@ func PrepareAndSendSubmissionInformationPackage(kafkaEndpoints []string, transfe
 
 	defer sender.writer.Close()
 
-	items, err := os.ReadDir(rootPath)
+	latestMessages, err := readLatestMessages(kafkaEndpoints, transferTopicName)
 	if err != nil {
-		return fmt.Errorf("failed to read root path '%s', original error: '%w'", rootPath, err)
+		return fmt.Errorf("failed to read latest messages, original error: '%w'", err)
 	}
-	for _, path := range items {
-		if path.IsDir() {
-			directoryName := path.Name()
-			destinationPath := rootPath + directoryName
-			fmt.Printf("Processing directory %s\n", destinationPath)
-			transferSubmissionInformationPackage := createSubmissionInformationPackage(destinationPath, directoryName)
 
-			kafkaMessage, err := json.Marshal(transferSubmissionInformationPackage)
-			if err != nil {
-				return fmt.Errorf("failed to marshal json, original error: '%w'", err)
-			}
+	relevantMessages, err := webArchiveRelevantMessages(latestMessages)
+	if err != nil {
+		return fmt.Errorf("failed to filter out relevant messages, original error: '%w'", err)
+	}
+	config := bigcache.Config{
+		Shards:      1024,
+		LifeWindow:  24 * time.Hour,
+		CleanWindow: 1 * time.Hour,
+	}
+	cache, err := bigcache.New(context.Background(), config)
+	if err != nil {
+		return fmt.Errorf("failed to create cache, original error: '%w'", err)
+	}
 
-			err = sender.sendMessageToKafkaTopic(kafkaMessage)
-			if err != nil {
-				return fmt.Errorf("failed to send message to kafka topic '%s', original error: '%w'", transferTopicName, err)
-			}
-		} else {
-			return fmt.Errorf("found file '%s' in root path '%s', but expected only directories", path.Name(), rootPath)
+	for _, message := range relevantMessages {
+		fmt.Printf("Pushing '%s' to cache\n", message.Path)
+		err := cache.Set(message.Path, []byte("Sent"))
+		if err != nil {
+			return fmt.Errorf("failed to set '%s' in cache, original error: '%w'", message.Path, err)
 		}
 	}
 
-	return nil
+	for {
+		items, err := os.ReadDir(rootPath)
+		if err != nil {
+			return fmt.Errorf("failed to read root path '%s', original error: '%w'", rootPath, err)
+		}
+		for _, path := range items {
+			directoryName := path.Name()
+			destinationPath := rootPath + directoryName
+			_, err := cache.Get(destinationPath)
+			if err == nil {
+				fmt.Printf("Skipping directory '%s' as it has already been processed.\n", destinationPath)
+				continue
+			} else {
+				if !errors.Is(err, bigcache.ErrEntryNotFound) {
+					return fmt.Errorf("failed to get '%s' from cache, original error: '%w'", destinationPath, err)
+				}
+			}
+			if path.IsDir() {
+
+				fmt.Printf("Processing directory %s\n", destinationPath)
+				transferSubmissionInformationPackage := createSubmissionInformationPackage(destinationPath, directoryName)
+
+				kafkaMessage, err := json.Marshal(transferSubmissionInformationPackage)
+				if err != nil {
+					return fmt.Errorf("failed to marshal json, original error: '%w'", err)
+				}
+
+				err = sender.sendMessageToKafkaTopic(kafkaMessage)
+				if err != nil {
+					return fmt.Errorf("failed to send message to kafka topic '%s', original error: '%w'", transferTopicName, err)
+				}
+				err = cache.Set(destinationPath, []byte("Sent"))
+				if err != nil {
+					return fmt.Errorf("failed to set '%s' in cache, original error: '%w'", destinationPath, err)
+				}
+			} else {
+				return fmt.Errorf("found file '%s' in root path '%s', but expected only directories", path.Name(), rootPath)
+			}
+		}
+		time.Sleep(1 * time.Minute)
+	}
 }
 
 func createSubmissionInformationPackage(payloadPath string, payloadDirName string) TransferSubmissionInformationPackage {

--- a/internal/send/send_test.go
+++ b/internal/send/send_test.go
@@ -53,3 +53,33 @@ func TestCreateSubmissionInformationPackage(t *testing.T) {
 		t.Errorf("Expected %s to be before %s", date, expectedDate)
 	}
 }
+
+func TestWebArchiveRelevantMessages(t *testing.T) {
+	nettarkivetMessage := TransferSubmissionInformationPackage{
+		Date:            time.Now().UTC().Format("2006-01-02T15:04:05.000"),
+		ContentCategory: "nettarkiv",
+		ContentType:     "warc",
+		Identifier:      "not-important",
+		Urn:             "not-important",
+		Path:            "not-important",
+	}
+	otherMessage := TransferSubmissionInformationPackage{
+		Date:            time.Now().UTC().Format("2006-01-02T15:04:05.000"),
+		ContentCategory: "other",
+		ContentType:     "other",
+		Identifier:      "other",
+		Urn:             "other",
+		Path:            "other",
+	}
+	messages := []TransferSubmissionInformationPackage{nettarkivetMessage, otherMessage}
+	filteredResults, err := webArchiveRelevantMessages(messages)
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	if len(filteredResults) != 1 {
+		t.Errorf("Expected 1 message, got %d", len(filteredResults))
+	}
+	if filteredResults[0] != nettarkivetMessage {
+		t.Errorf("Expected '%+v', got '%s'", nettarkivetMessage, filteredResults[0])
+	}
+}


### PR DESCRIPTION
# Motivation

To avoid sending the same messages again and again if the service is restarted, we now take into account the previous state of the `kafka` topic.

This ensures we will get a lot fewer false-positive notifications when notifications are enabled.

# Implementation

In short, this is what happens:

* All messages between the first and last offsets are read.
* The messages that do not belong to `nettarkivet` are filtered away
* The remaining messages `Path` value are put in a cache
* The cache is consulted before sending a message to the transfer topic
   - If the `Path` evaluated is already in the cache, it is not sent
   - Otherwise, a `kafka` message is sent to the transfer topic

In addition, now the program will not exit after sending the messages, but rather run a forever loop every 1 minute.

# Quirks

## Cache configuration

The configuration of the cache might be tuned to avoid memory issues. Each of the entries in the cache is stored there for 24 hours, but this might need to be evaluated if the amount of data we send increases.

## Valid offsets

Currently, all offsets between the first and last offset are read. But sometimes certain offsets might be deleted, these are currently ignored, but could potentially be a source of bugs in the future.