### PR TITLE
refactor: create kafka helpers

### DIFF
--- a/internal/kafka/reader.go
+++ b/internal/kafka/reader.go
@@ -1,0 +1,18 @@
+package kafka
+
+import (
+	"context"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+)
+
+type MessageReader struct {
+	Reader *kafka.Reader
+}
+
+func (reader *MessageReader) ReadMessageWithTimeout(timeout time.Duration) (message kafka.Message, err error) {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return reader.Reader.ReadMessage(ctxTimeout)
+}

--- a/internal/kafka/sender.go
+++ b/internal/kafka/sender.go
@@ -1,0 +1,34 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/segmentio/kafka-go"
+)
+
+type Sender struct {
+	Writer *kafka.Writer
+}
+
+func (sender *Sender) SendMessageToKafkaTopic(payload []byte) error {
+	kafkaMessageUuid := uuid.New()
+	fmt.Printf("Sending message with uuid %s\n", kafkaMessageUuid)
+	kafkaMessageUuidBytes, err := kafkaMessageUuid.MarshalText()
+	if err != nil {
+		return fmt.Errorf("failed to marshal uuid, original error: '%w'", err)
+	}
+
+	err = sender.Writer.WriteMessages(context.Background(),
+		kafka.Message{
+			Key:   kafkaMessageUuidBytes,
+			Value: payload,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to write messages, original error: '%w'", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit creates a new package `internal/kafka` that contains helpers for sending and receiving messages from Kafka. The `send.go` package is refactored to use these helpers.

This is in preparation for adding the `verify` implementation.