### PR TITLE
feat: verification implementation

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -2,6 +2,8 @@ package verify
 
 import (
 	"fmt"
+	"hermetic/internal/common_flags"
+	verifyImplementation "hermetic/internal/verify"
 
 	"github.com/spf13/cobra"
 )
@@ -24,11 +26,9 @@ func NewCommand() *cobra.Command {
 }
 
 func parseArgumentsAndCallVerify(cmd *cobra.Command, args []string) error {
-	fmt.Println("Parsing verify arguments")
-	return verify()
-}
-
-func verify() error {
-	fmt.Println("Running verify")
-	return nil
+	rejectTopicName, err := cmd.Flags().GetString("reject-topic")
+	if err != nil {
+		return fmt.Errorf("failed to get reject-topic flag, cause: `%w`", err)
+	}
+	return verifyImplementation.Verify(rejectTopicName, common_flags.KafkaEndpoints, common_flags.TeamsWebhookNotificationUrl)
 }

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -1,9 +1,0 @@
-package verify
-
-import "testing"
-
-func TestValidateCmdName(t *testing.T) {
-	if err := verify(); err != nil {
-		panic("verify failed")
-	}
-}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.20
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
+	github.com/carlmjohnson/requests v0.23.4
+	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.4.0
 	github.com/segmentio/kafka-go v0.4.44
 	github.com/spf13/cobra v1.7.0
@@ -14,4 +16,6 @@ require (
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	golang.org/x/net v0.17.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
 github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
+github.com/carlmjohnson/requests v0.23.4 h1:AxcvapfB9RPXLSyvAHk9YJoodQ43ZjzNHj6Ft3tQGdg=
+github.com/carlmjohnson/requests v0.23.4/go.mod h1:Qzp6tW4DQyainPP+tGwiJTzwxvElTIKm0B191TgTtOA=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -24,8 +28,9 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/internal/teams/teams.go
+++ b/internal/teams/teams.go
@@ -1,0 +1,49 @@
+package teams
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/carlmjohnson/requests"
+)
+
+type Fact struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type Section struct {
+	ActivityTitle    string `json:"activityTitle"`
+	ActivitySubtitle string `json:"activitySubtitle"`
+	ActivityImage    string `json:"activityImage"`
+	Facts            []Fact `json:"facts"`
+}
+
+type Message struct {
+	Type       string    `json:"@type"`
+	Context    string    `json:"@context"`
+	ThemeColor string    `json:"themeColor"`
+	Summary    string    `json:"summary"`
+	Sections   []Section `json:"sections"`
+}
+
+func SendMessage(payload Message, webhookUrl string) error {
+	timeoutContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	fmt.Println("Sending message to Teams")
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message, cause: `%w`", err)
+	}
+	err = requests.
+		URL(webhookUrl).
+		BodyBytes(bytes).
+		ContentType("text/plain").
+		Fetch(timeoutContext)
+	if err != nil {
+		return fmt.Errorf("failed to send message to teams, cause: `%w`", err)
+	}
+	return nil
+}

--- a/internal/verify/teams_message.go
+++ b/internal/verify/teams_message.go
@@ -1,0 +1,86 @@
+package verifyImplementation
+
+import (
+	"fmt"
+	"hermetic/internal/teams"
+	"strconv"
+	"strings"
+)
+
+func createTeamsDigitalPreservationSystemFailureMessage(message kafkaResponse, rejectTopicName string, kafkaEndpoints []string) teams.Message {
+	facts := []teams.Fact{
+		{
+			Name:  "Kafka message offset",
+			Value: strconv.FormatInt(message.Offset, 10),
+		},
+		{
+			Name:  "Kafka message key",
+			Value: message.Key,
+		},
+		{
+			Name:  "Kafka topic",
+			Value: rejectTopicName,
+		},
+		{
+			Name:  "Kafka endpoints",
+			Value: strings.Join(kafkaEndpoints, ", "),
+		},
+		{
+			Name:  "Identifier",
+			Value: message.DPSResponse.Identifier,
+		},
+		{
+			Name:  "Urn",
+			Value: message.DPSResponse.Urn,
+		},
+		{
+			Name:  "Path",
+			Value: message.DPSResponse.Path,
+		},
+		{
+			Name:  "ContentType",
+			Value: message.DPSResponse.ContentType,
+		},
+		{
+			Name:  "ContentCategory",
+			Value: message.DPSResponse.ContentCategory,
+		},
+		{
+			Name:  "Date of submission",
+			Value: message.DPSResponse.Date,
+		},
+	}
+	for index, check := range message.DPSResponse.Checks {
+		facts = append(facts, teams.Fact{
+			Name:  fmt.Sprintf("Check #%d status", index),
+			Value: check.Status,
+		})
+		facts = append(facts, teams.Fact{
+			Name:  fmt.Sprintf("Check #%d message", index),
+			Value: check.Message,
+		})
+		facts = append(facts, teams.Fact{
+			Name:  fmt.Sprintf("Check #%d reason", index),
+			Value: check.Reason,
+		})
+		facts = append(facts, teams.Fact{
+			Name:  fmt.Sprintf("Check #%d file", index),
+			Value: check.File,
+		})
+	}
+
+	return teams.Message{
+		Type:       "MessageCard",
+		Context:    "http://schema.org/extensions",
+		ThemeColor: "0076D7",
+		Summary:    "Verification error",
+		Sections: []teams.Section{
+			{
+				ActivityTitle:    "Verification error",
+				ActivitySubtitle: "A Digital Preservation System (DPS) upload failed",
+				ActivityImage:    "https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1-300x300.jpg",
+				Facts:            facts,
+			},
+		},
+	}
+}

--- a/internal/verify/teams_message_test.go
+++ b/internal/verify/teams_message_test.go
@@ -1,0 +1,126 @@
+package verifyImplementation
+
+import (
+	"encoding/json"
+	"fmt"
+	"hermetic/internal/teams"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCreateTeamsMessage(t *testing.T) {
+	kafkaResponse := kafkaResponse{
+		Offset: 0,
+		Key:    "key",
+		DPSResponse: digitalPreservationSystemResponse{
+			Date:            "date",
+			Identifier:      "identifier",
+			Urn:             "urn",
+			Path:            "path",
+			ContentType:     "contentType",
+			ContentCategory: "contentCategory",
+			Checks: []check{
+				{
+					Status:  "status",
+					Message: "message",
+					Reason:  "reason",
+					File:    "file",
+				},
+			},
+		},
+	}
+	rejectTopicName := "rejectTopicName"
+	kafkaEndpoints := []string{"kafkaEndpoints"}
+
+	message := createTeamsDigitalPreservationSystemFailureMessage(
+		kafkaResponse,
+		rejectTopicName,
+		kafkaEndpoints,
+	)
+	expectedMessage := teams.Message{
+		Type:       "MessageCard",
+		Context:    "http://schema.org/extensions",
+		ThemeColor: "0076D7",
+		Summary:    "Verification error",
+		Sections: []teams.Section{
+			{
+				ActivityTitle:    "Verification error",
+				ActivitySubtitle: "A Digital Preservation System (DPS) upload failed",
+				ActivityImage:    "https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1-300x300.jpg",
+
+				Facts: []teams.Fact{
+					{
+						Name:  "Kafka message offset",
+						Value: "0",
+					},
+					{
+						Name:  "Kafka message key",
+						Value: "key",
+					},
+					{
+						Name:  "Kafka topic",
+						Value: "rejectTopicName",
+					},
+					{
+						Name:  "Kafka endpoints",
+						Value: "kafkaEndpoints",
+					},
+					{
+						Name:  "Identifier",
+						Value: "identifier",
+					},
+					{
+						Name:  "Urn",
+						Value: "urn",
+					},
+					{
+						Name:  "Path",
+						Value: "path",
+					},
+					{
+						Name:  "ContentType",
+						Value: "contentType",
+					},
+					{
+						Name:  "ContentCategory",
+						Value: "contentCategory",
+					},
+					{
+						Name:  "Date of submission",
+						Value: "date",
+					},
+					{
+						Name:  "Check #0 status",
+						Value: "status",
+					},
+					{
+						Name:  "Check #0 message",
+						Value: "message",
+					},
+					{
+						Name:  "Check #0 reason",
+						Value: "reason",
+					},
+					{
+						Name:  "Check #0 file",
+						Value: "file",
+					},
+				},
+			},
+		},
+	}
+	if !cmp.Equal(message, expectedMessage) {
+		t.Errorf("Expected message to be: '%v'\n, got: \n'%v'", prettify(expectedMessage), prettify(message))
+	}
+
+}
+
+func prettify(message teams.Message) string {
+	s, err := json.MarshalIndent(message, "", "\t")
+
+	if err != nil {
+		panic(fmt.Sprintf("Failed to prettify message: %v", err))
+	}
+	return string(s)
+}

--- a/internal/verify/types.go
+++ b/internal/verify/types.go
@@ -1,0 +1,24 @@
+package verifyImplementation
+
+type check struct {
+	Status  string
+	Message string
+	Reason  string
+	File    string
+}
+
+type digitalPreservationSystemResponse struct {
+	Date            string
+	Identifier      string
+	Urn             string
+	Path            string
+	ContentType     string
+	ContentCategory string
+	Checks          []check
+}
+
+type kafkaResponse struct {
+	Offset      int64
+	Key         string
+	DPSResponse digitalPreservationSystemResponse
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,0 +1,71 @@
+package verifyImplementation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hermetic/internal/teams"
+	"time"
+
+	kafkaHelpers "hermetic/internal/kafka"
+
+	"github.com/segmentio/kafka-go"
+)
+
+func isWebArchiveOwned(message kafkaResponse) bool {
+	return message.DPSResponse.ContentCategory == "nettarkiv"
+}
+
+func Verify(rejectTopicName string, kafkaEndpoints []string, teamsWebhookNotificationUrl string) error {
+	reader := kafkaHelpers.MessageReader{
+		Reader: kafka.NewReader(kafka.ReaderConfig{
+			Brokers: kafkaEndpoints,
+			Topic:   rejectTopicName,
+			GroupID: "nettarkivet-hermetic-verify",
+		}),
+	}
+	readTimeout := 10 * time.Second
+	cycleSleepDuration := 1 * time.Minute
+
+	for {
+		fmt.Printf("Reading next message with timeout '%s'\n", readTimeout)
+		message, err := reader.ReadMessageWithTimeout(readTimeout)
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Printf("Reading message timed out, sleeping for '%s'\n", cycleSleepDuration)
+			time.Sleep(cycleSleepDuration)
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read message, cause: `%w`", err)
+		}
+		var parsedMessage digitalPreservationSystemResponse
+
+		err = json.Unmarshal(message.Value, &parsedMessage)
+		if err != nil {
+			syntaxError := new(json.SyntaxError)
+			if errors.As(err, &syntaxError) {
+				fmt.Printf("Could not read message at offset '%d', syntax error in message, skipping offset\n", message.Offset)
+				continue
+			}
+			return fmt.Errorf("failed to unmarshal json, original error: '%w'", err)
+		}
+		response := kafkaResponse{
+			Offset:      message.Offset,
+			Key:         string(message.Key),
+			DPSResponse: parsedMessage,
+		}
+
+		if !isWebArchiveOwned(response) {
+			fmt.Printf("Skipping message with ContentCategory: '%s'\n", response.DPSResponse.ContentCategory)
+			continue
+		}
+
+		fmt.Printf("Processing message with ContentCategory: '%s'\n", response.DPSResponse.ContentCategory)
+		payload := createTeamsDigitalPreservationSystemFailureMessage(response, rejectTopicName, kafkaEndpoints)
+		err = teams.SendMessage(payload, teamsWebhookNotificationUrl)
+		if err != nil {
+			return fmt.Errorf("failed to send message to teams, cause: `%w`", err)
+		}
+	}
+}

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1,0 +1,59 @@
+package verifyImplementation
+
+import (
+	"testing"
+)
+
+func TestIsWebArchiveOwnedInvalid(t *testing.T) {
+	notWebArchive := kafkaResponse{
+		Offset: int64(0),
+		Key:    "key",
+
+		DPSResponse: digitalPreservationSystemResponse{
+			ContentCategory: "something else",
+			Date:            "date",
+			Identifier:      "identifier",
+			Urn:             "urn",
+			Path:            "path",
+			ContentType:     "contentType",
+			Checks: []check{
+				{
+					Status:  "status",
+					Message: "message",
+					Reason:  "reason",
+					File:    "file",
+				},
+			},
+		},
+	}
+	if isWebArchiveOwned(notWebArchive) {
+		t.Errorf("Expected false, got true")
+	}
+}
+func TestIsWebArchiveOwnedValid(t *testing.T) {
+	webArchiveResponse := kafkaResponse{
+		Offset: int64(0),
+		Key:    "key",
+
+		DPSResponse: digitalPreservationSystemResponse{
+			ContentCategory: "nettarkiv",
+			Date:            "date",
+			Identifier:      "identifier",
+			Urn:             "urn",
+			Path:            "path",
+			ContentType:     "contentType",
+			Checks: []check{
+				{
+					Status:  "status",
+					Message: "message",
+					Reason:  "reason",
+					File:    "file",
+				},
+			},
+		},
+	}
+	if !isWebArchiveOwned(webArchiveResponse) {
+		t.Errorf("Expected true, got false")
+	}
+
+}


### PR DESCRIPTION
# Motivation

This commit adds the implementation of the verification command. The interface has been specified in commit
d6a9fd5c6a8d99ac36cca361fe65af1dad594f69, but the interface was expanded in commit 7cb6c6e33d19bbeddcc641721c2807157856f933.

# Implementation

In summary, the verification will happen like this:

1. Read the next message from the consumer group
2. If the message is not owned by the web archive, return to step 1.
3. If we get a read timeout, sleep for 1 minute and return to step 1.
4. Create a Teams message and send it to the relevant channel
5. Return to step 1.

# Considerations

If the verification service fails between steps 1 and 4, a message could be read from the consumer group, but will not be sent to the Teams channel successfully. This means that the message will be lost.

# Future work

If unexpected errors occur no message will be sent to Teams and it will be difficult to know that the service has failed. This could be remedied by always sending a message to Teams whenever an error is detected.