### PR TITLE
fix: send `Teams` error message on system failure

### DIFF
--- a/internal/teams/teams.go
+++ b/internal/teams/teams.go
@@ -47,3 +47,26 @@ func SendMessage(payload Message, webhookUrl string) error {
 	}
 	return nil
 }
+
+func CreateGeneralFailureMessage(failure error) Message {
+	facts := []Fact{
+		{
+			Name:  "Error",
+			Value: failure.Error(),
+		},
+	}
+	return Message{
+		Type:       "MessageCard",
+		Context:    "http://schema.org/extensions",
+		ThemeColor: "0076D7",
+		Summary:    "System error",
+		Sections: []Section{
+			{
+				ActivityTitle:    "System error",
+				ActivitySubtitle: "A Digital Preservation System (DPS) general failure",
+				ActivityImage:    "https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1-300x300.jpg",
+				Facts:            facts,
+			},
+		},
+	}
+}


### PR DESCRIPTION
# Motivation

If something unexpected happens, like an unhandled error, a message will be sent to `Teams` notifying the users that something is wrong. This will reduce the cognitive load of the users since they don't have to check the logs to see if something is wrong.

# Future work

The errors could be unwrapped for a nicer user experience, but at this point, it seems like premature optimization.