### PR TITLE
fix: use `UUID` in identifier

### DIFF
--- a/internal/send/send.go
+++ b/internal/send/send.go
@@ -12,6 +12,7 @@ import (
 	kafkaHelpers "hermetic/internal/kafka"
 
 	"github.com/allegro/bigcache/v3"
+	"github.com/google/uuid"
 	"github.com/segmentio/kafka-go"
 )
 
@@ -207,8 +208,9 @@ func createSubmissionInformationPackage(payloadPath string, payloadDirName strin
 	date := time.Now().UTC().Format("2006-01-02T15:04:05.000")
 	contentCategory := "nettarkiv"
 	contentType := "warc"
-	identifier := "no-nb_" + contentCategory + "_" + payloadDirName
-	urn := "URN:NBN:" + identifier
+	commonPart := "no-nb_" + contentCategory + "_" + payloadDirName
+	identifier := commonPart + "_" + uuid.New().String()
+	urn := "URN:NBN:" + commonPart
 
 	return TransferSubmissionInformationPackage{
 		Date:            date,

--- a/internal/send/send_test.go
+++ b/internal/send/send_test.go
@@ -1,6 +1,7 @@
 package sendImplementation
 
 import (
+	"regexp"
 	"testing"
 	"time"
 )
@@ -11,7 +12,7 @@ func TestCreateSubmissionInformationPackage(t *testing.T) {
 		Date:            time.Now().UTC().Format(dateFormat),
 		ContentCategory: "nettarkiv",
 		ContentType:     "warc",
-		Identifier:      "no-nb_nettarkiv_nettaviser_SCREENSHOT_2023-20230718002403-0216-veidemann-contentwriter-5bb4677d67-qwtmt",
+		Identifier:      "no-nb_nettarkiv_nettaviser_SCREENSHOT_2023-20230718002403-0216-veidemann-contentwriter-5bb4677d67-qwtmt_[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}", //https://regex101.com/r/0XbiJ6/1
 		Urn:             "URN:NBN:no-nb_nettarkiv_nettaviser_SCREENSHOT_2023-20230718002403-0216-veidemann-contentwriter-5bb4677d67-qwtmt",
 		Path:            "/path/to/nettaviser_SCREENSHOT_2023-20230718002403-0216-veidemann-contentwriter-5bb4677d67-qwtmt/nettaviser_SCREENSHOT_2023-20230718002403-0216-veidemann-contentwriter-5bb4677d67-qwtmt.warc.gz",
 	}
@@ -26,8 +27,10 @@ func TestCreateSubmissionInformationPackage(t *testing.T) {
 		t.Errorf("Expected %s, got %s", expectedSubmissionInformationPackage.ContentType, submissionInformationPackage.ContentType)
 	}
 
-	if expectedSubmissionInformationPackage.Identifier != submissionInformationPackage.Identifier {
-		t.Errorf("Expected %s, got %s", expectedSubmissionInformationPackage.Identifier, submissionInformationPackage.Identifier)
+	var compiledIdentifier = regexp.MustCompile(expectedSubmissionInformationPackage.Identifier)
+
+	if !compiledIdentifier.MatchString(submissionInformationPackage.Identifier) {
+		t.Errorf("Expected %s to match %s", submissionInformationPackage.Identifier, compiledIdentifier)
 	}
 
 	if expectedSubmissionInformationPackage.Urn != submissionInformationPackage.Urn {


### PR DESCRIPTION
# Motivation

Commit 60d388416df2c3fc89cbe338226cf2f6e27096eb mistakenly assumed that `URN`s are unchangeable, but this is not the case. In certain situations, there might be a reupload of the same `URN`, for example when something was uploaded with the wrong name.

The true unchangeable reference to the object is the `identifier`, which with the current implementation is not going to be unique on a reupload.

Ideally the `identifier` should not be provided by `hermetic`, but be returned by `Digital Preservation System` (DPS), but unfortunately this is not the case.

# Workaround

To avoid this problem we simply add a `UUID` to the end of the `identifier` and unlink the `URN` from the `identifier`. The UUID version is version 4.

Theoretically, there is a chance that the `UUID` is not unique, but the likelihood is, according to
[Wikipedia](https://en.wikipedia.org/wiki/Universally_unique_identifier#Collisions), this:

```
For example, the number of random version-4 UUIDs which need to be
generated in order to have a 50% probability of at least one collision
is 2.71 quintillion
```