### PR TITLE
feat: `acquisition` validation and upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ hermetic verify \
     --kafka-endpoints=<list-of-kafka-endpoints> \
     --reject-topic <topic-name>
 ```
+
+### Acquisition upload
+
+```shell
+hermetic acquistion \
+    --kafka-endpoints=<list-of-kafka-endpoints> \
+    --transfer-topic <topic-name> \
+    --acquisition-root=</path/to/root/of/acquisition>
+```

--- a/cmd/acquisition/acquisition.go
+++ b/cmd/acquisition/acquisition.go
@@ -1,0 +1,59 @@
+package acquisition
+
+import (
+	"fmt"
+	acquisitionImplementation "hermetic/internal/acquisition"
+	"hermetic/internal/common_flags"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	transferTopicFlagName   string = "transfer-topic"
+	acquisitionRootFlagName string = "acquisition-root"
+)
+
+func NewCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "acquisition",
+		Short: "Uploads data to digital storage",
+		Args:  cobra.NoArgs,
+		RunE:  parseArgumentsAndCallAcquisition,
+	}
+	command.Flags().String(transferTopicFlagName, "", "name of transfer-topic")
+	if markTransferRequiredError := command.MarkFlagRequired(transferTopicFlagName); markTransferRequiredError != nil {
+		panic(fmt.Sprintf("failed to mark flag %s as required, original error: '%s'", transferTopicFlagName, markTransferRequiredError))
+	}
+
+	command.Flags().String(acquisitionRootFlagName, "", `path to the root directory with the following content structure:
+/acquisition-root
+├── checksums.md5
+├── checksum_transferred.md5
+├── /acquisition.yaml
+├── <other-small-and-few-files>
+└── /<other-files-and-directories>
+`)
+	if err := command.MarkFlagRequired(acquisitionRootFlagName); err != nil {
+		panic(fmt.Sprintf("failed to mark flag %s as required, original error: '%s'", acquisitionRootFlagName, err))
+	}
+
+	return command
+}
+
+func parseArgumentsAndCallAcquisition(cmd *cobra.Command, args []string) error {
+	transferTopicName, err := cmd.Flags().GetString(transferTopicFlagName)
+	if err != nil {
+		return fmt.Errorf("getting transfer topic name failed, original error: '%w'", err)
+	}
+	acquisitionRoot, err := cmd.Flags().GetString(acquisitionRootFlagName)
+	if err != nil {
+		return fmt.Errorf("getting stage artifacts root failed, original error: '%w'", err)
+	}
+
+	err = acquisitionImplementation.PrepareAndSendSubmissionInformationPackage(common_flags.KafkaEndpoints, transferTopicName, acquisitionRoot)
+	if err != nil {
+		return fmt.Errorf("transfer error, cause: `%w`", err)
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"hermetic/cmd/acquisition"
 	"hermetic/cmd/send"
 	"hermetic/cmd/verify"
 	"hermetic/internal/common_flags"
@@ -17,5 +18,6 @@ func NewRootCommand() *cobra.Command {
 	rootCommand.PersistentFlags().StringVar(&common_flags.TeamsWebhookNotificationUrl, "teams-webhook-notification-url", "", "url to teams webhook for notifications")
 	rootCommand.AddCommand(send.NewCommand())
 	rootCommand.AddCommand(verify.NewCommand())
+	rootCommand.AddCommand(acquisition.NewCommand())
 	return rootCommand
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/spf13/cobra v1.8.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/acquisition/acquisition.go
+++ b/internal/acquisition/acquisition.go
@@ -1,0 +1,205 @@
+package acquisitionImplementation
+
+import (
+	"encoding/json"
+	"fmt"
+	kafkaHelpers "hermetic/internal/kafka"
+	"hermetic/internal/path"
+	"hermetic/internal/submission_information_package"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	contentType                 = "acquisition"
+	supportedAcquisitionVersion = "0.1.0"
+)
+
+type DataModel struct {
+	AcquisitionVersion string `yaml:"__acquisition_version__"`
+	Acquisition        struct {
+		Name                 string `yaml:"name"`
+		Date                 string `yaml:"date"`
+		OriginalPurpose      string `yaml:"original-purpose"`
+		AcquisitionPurpose   string `yaml:"acquisition-purpose"`
+		AccessConsiderations string `yaml:"access-considerations"`
+	} `yaml:"acquisition"`
+
+	Files []struct {
+		Name        string `yaml:"name"`
+		Format      string `yaml:"format"`
+		Path        string `yaml:"path"`
+		Description string `yaml:"description"`
+	} `yaml:"files"`
+	AcquisitionHandling struct {
+		Responsible string `yaml:"responsible"`
+		Author      string `yaml:"author"`
+	} `yaml:"acquisition-handling"`
+}
+
+func PrepareAndSendSubmissionInformationPackage(kafkaEndpoints []string, transferTopicName string, acquisitionRoot string) error {
+	sender := kafkaHelpers.Sender{
+		Writer: &kafka.Writer{
+			Addr:     kafka.TCP(kafkaEndpoints...),
+			Topic:    transferTopicName,
+			Balancer: &kafka.LeastBytes{},
+		},
+	}
+	defer sender.Writer.Close()
+	isDir, err := path.IsDirectory(acquisitionRoot)
+	if err != nil {
+		return fmt.Errorf("failed to check if '%s' is a directory, original error: '%w'", acquisitionRoot, err)
+	}
+	if !isDir {
+		return fmt.Errorf("acquisitionRoot ('%s') is not a directory", acquisitionRoot)
+	}
+
+	dataModel, err := deserializeYamlFile(filepath.Join(acquisitionRoot, "acquisition.yaml"))
+	if err != nil {
+		return fmt.Errorf("failed to deserialize yaml file, original error: '%w'", err)
+	}
+
+	if err := validate(acquisitionRoot, dataModel); err != nil {
+		return fmt.Errorf("failed to process yaml file, original error: '%w'", err)
+	}
+
+	identifier := dataModel.Acquisition.Name + "-" + dataModel.Acquisition.Date
+
+	submissionInformationPackage := submission_information_package.CreatePackage(acquisitionRoot, identifier, contentType)
+
+	expectedURN := "URN:NBN:no-nb_nettarkiv_" + dataModel.Acquisition.Name + "-" + dataModel.Acquisition.Date
+
+	if submissionInformationPackage.Urn != expectedURN {
+		return fmt.Errorf("failed to create URN, expected %s, got %s", expectedURN, submissionInformationPackage.Urn)
+	}
+
+	kafkaMessage, err := json.Marshal(submissionInformationPackage)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json, original error: '%w'", err)
+	}
+
+	err = sender.SendMessageToKafkaTopic(kafkaMessage)
+	if err != nil {
+		return fmt.Errorf("failed to send message to kafka topic '%s', original error: '%w'", transferTopicName, err)
+	}
+
+	return nil
+}
+
+func deserializeYamlFile(metadataFilePath string) (DataModel, error) {
+	var dataModel DataModel
+
+	content, err := os.ReadFile(metadataFilePath)
+	if err != nil {
+		return dataModel, fmt.Errorf("failed to read file '%s', original error: '%w'", metadataFilePath, err)
+	}
+
+	err = yaml.Unmarshal(content, &dataModel)
+	if err != nil {
+		return dataModel, fmt.Errorf("failed to unmarshal yaml, original error: '%w'", err)
+	}
+	return dataModel, nil
+}
+
+func validate(rootPath string, dataModel DataModel) error {
+	// TODO(https://github.com/nlnwa/hermetic/issues/32): This YAML file should
+	// be replaced by more sustainable solution based on industry standards,
+	// such as METS https://www.loc.gov/standards/mets/mets-schemadocs.html and
+	// PREMIS https://www.loc.gov/standards/premis/
+
+	if dataModel.AcquisitionVersion != supportedAcquisitionVersion {
+		return fmt.Errorf("acquisition version '%s' is not supported, expected %s", dataModel.AcquisitionVersion, supportedAcquisitionVersion)
+	}
+
+	if err := directoryValidation(rootPath); err != nil {
+		return fmt.Errorf("failed to validate directories, original error: '%w'", err)
+	}
+
+	if err := fileValidation(rootPath, dataModel); err != nil {
+		return fmt.Errorf("failed to validate files, original error: '%w'", err)
+	}
+
+	if err := otherMetadataValidation(dataModel); err != nil {
+		return fmt.Errorf("failed to validate other metadata, original error: '%w'", err)
+	}
+
+	return nil
+}
+
+func directoryValidation(rootPath string) error {
+	items, err := os.ReadDir(rootPath)
+	if err != nil {
+		return fmt.Errorf("failed to read root path '%s', original error: '%w'", rootPath, err)
+	}
+
+	for _, path := range items {
+		if path.IsDir() {
+			return fmt.Errorf("found directory '%s' in root path '%s', but expected only files", path.Name(), rootPath)
+		}
+	}
+
+	return nil
+}
+
+func fileValidation(rootPath string, metadata DataModel) error {
+	for _, file := range metadata.Files {
+		resolvedPath := filepath.Join(rootPath, file.Path)
+		isFile, err := path.IsFile(resolvedPath)
+		if err != nil {
+			return fmt.Errorf("failed to check if '%s' is a file, original error: '%w'", resolvedPath, err)
+		}
+		if !isFile {
+			return fmt.Errorf("file '%s' is not a file", resolvedPath)
+		}
+	}
+
+	items, err := os.ReadDir(rootPath)
+	if err != nil {
+		return fmt.Errorf("failed to read root path '%s', original error: '%w'", rootPath, err)
+	}
+
+	for _, path := range items {
+		found := false
+		if !path.IsDir() {
+			for _, yamlFile := range metadata.Files {
+				if yamlFile.Path == path.Name() {
+					found = true
+					continue
+				}
+			}
+			if !found {
+				return fmt.Errorf("found file '%s' in root path '%s', but expected only files specified in yaml file", path.Name(), rootPath)
+			}
+
+		}
+	}
+
+	return nil
+}
+
+func otherMetadataValidation(metadata DataModel) error {
+	test := map[string]string{}
+	test["metadata.Acquisition.Name"] = metadata.Acquisition.Name
+	test["metadata.Acquisition.Date"] = metadata.Acquisition.Date
+	test["metadata.Acquisition.OriginalPurpose"] = metadata.Acquisition.OriginalPurpose
+	test["metadata.Acquisition.AcquisitionPurpose"] = metadata.Acquisition.AcquisitionPurpose
+	test["metadata.Acquisition.AccessConsiderations"] = metadata.Acquisition.AccessConsiderations
+	test["metadata.AcquisitionHandling.Responsible"] = metadata.AcquisitionHandling.Responsible
+	test["metadata.AcquisitionHandling.Author"] = metadata.AcquisitionHandling.Author
+
+	for fieldName, value := range test {
+		if value == "" {
+			return fmt.Errorf("field '%s' is empty", fieldName)
+		}
+	}
+	_, err := time.Parse(time.RFC3339, metadata.Acquisition.Date)
+	if err != nil {
+		return fmt.Errorf("failed to parse date '%s', original error: '%w'", metadata.Acquisition.Date, err)
+	}
+
+	return nil
+}

--- a/internal/acquisition/acquisition_test.go
+++ b/internal/acquisition/acquisition_test.go
@@ -1,0 +1,78 @@
+package acquisitionImplementation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	workingDirectory, err := os.MkdirTemp("", "working-dir")
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	defer os.RemoveAll(workingDirectory)
+
+	acquisitionYamlFile, err := os.Create(filepath.Join(workingDirectory, "acquisition.yaml"))
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	_, err = os.Create(filepath.Join(workingDirectory, "checksum.md5"))
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	_, err = os.Create(filepath.Join(workingDirectory, "checksum_transferred.md5"))
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	_, err = os.Create(filepath.Join(workingDirectory, "dummy.txt"))
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+
+	_, err = acquisitionYamlFile.WriteString(`
+__acquisition_version__: "0.1.0"
+acquisition:
+    name: "dummy-acquisition"
+    date: "2024-01-03T09:29:16+00:00"
+    original-purpose: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    acquisition-purpose: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    access-considerations: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+
+files:
+    - name: "acquisition.yaml"
+      description: "This file"
+      format: "yaml"
+      path: "acquisition.yaml"
+    - name: "checksum.md5"
+      description: "Checksum file for this acquisition, generated with command 'find * -type f -print0 | sort -z | xargs -0 md5sum -b > /tmp/checksum.md5 && mv /tmp/checksum.md5 .'"
+      format: "md5"
+      path: "checksum.md5"
+    - name: "checksum_transferred.md5"
+      description: "Checksum file for packaged files"
+      format: "md5"
+      path: "checksum_transferred.md5"
+    - name: "dummy"
+      description: "Dummy file"
+      format: "plain"
+      path: "dummy.txt"
+
+acquisition-handling:
+    responsible: "nettarkivet"
+    author: "Unknown"
+`)
+
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+
+	dataModel, err := deserializeYamlFile(acquisitionYamlFile.Name())
+	if err != nil {
+		t.Errorf("Expected no error, got '%s' %s", err, acquisitionYamlFile.Name())
+	}
+
+	if err := validate(workingDirectory, dataModel); err != nil {
+		t.Errorf("Expected no error, got '%s' %s", err, acquisitionYamlFile.Name())
+	}
+
+}

--- a/internal/path/path.go
+++ b/internal/path/path.go
@@ -1,0 +1,23 @@
+package path
+
+import (
+	"fmt"
+	"os"
+)
+
+func IsDirectory(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("failed to get file info for '%s', original error: '%w'", path, err)
+	}
+
+	return fileInfo.IsDir(), err
+}
+
+func IsFile(path string) (bool, error) {
+	isDir, err := IsDirectory(path)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if '%s' is a directory, original error: '%w'", path, err)
+	}
+	return !isDir, err
+}

--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -1,0 +1,72 @@
+package path
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsDirectoryWithFile(t *testing.T) {
+	file, err := os.CreateTemp("", "test")
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	defer os.Remove(file.Name())
+
+	isDir, err := IsDirectory(file.Name())
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	if isDir {
+		t.Errorf("Expected '%s' to be a file", file.Name())
+	}
+}
+
+func TestIsDirectoryWithDirectory(t *testing.T) {
+	directory, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	defer os.Remove(directory)
+
+	isDir, err := IsDirectory(directory)
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	if !isDir {
+		t.Errorf("Expected '%s' to be a directory", directory)
+	}
+
+}
+
+func TestIsFileWithFile(t *testing.T) {
+	file, err := os.CreateTemp("", "test")
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	defer os.Remove(file.Name())
+
+	isFile, err := IsFile(file.Name())
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	if !isFile {
+		t.Errorf("Expected '%s' to be a file", file.Name())
+	}
+}
+
+func TestIsFileWithDirectory(t *testing.T) {
+	directory, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	defer os.Remove(directory)
+
+	isFile, err := IsFile(directory)
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err)
+	}
+	if isFile {
+		t.Errorf("Expected '%s' to be a directory", directory)
+	}
+
+}


### PR DESCRIPTION
# Motivation

Digital acquisitions are digital objects such as databases that the national library receives from various actors. These acquisitions need to be preserved and should therefore be uploaded to the digital archive.

To avoid accidentally uploading wrong data, a `YAML` file is used to give a high-level description of the acquisition. This file is then used to validate the acquisition before uploading it.

# Usage

To upload a digital acquisition, the following command can be used:

```shell
hermetic acquisition \
    --acquisition-root /path/to/root/of/acquisition \
    --transfer-topic <transfer-topic-name>
    --kafka-endpoints <list-of-kafka-endpoints>
```

# Implementation

To be able to upload this data, the data must be structured in a particular order:

```
/<root>
├── acquisition.yaml
├── checksums.md5
├── checksum_transferred.md5
├── <other-small-and-few-files>
├── main-payload.tar
├── main-payload2.tar
└── main-payload3.tar
```

Where `checksum.md5` contains the checksums for

* acquisition.yaml
* <other-small-and-few-files>
* main-payload.tar
* main-payload2.tar
* main-payload3.tar

and `checksum_transferred.md5` contains the checksums for all the files in the `tar` files:

* main-payload.tar
* main-payload2.tar
* main-payload3.tar

The checksums have been generated with the command

```shell
find * -type f -print0 | sort -z | xargs -0 md5sum -b > /tmp/checksum.md5 && mv /tmp/checksum.md5 .
```

# Validation

The current validation simply ensures that all of the files listed in `acquisition.yaml` exist and there are no unexpected files.

# Future work

Instead of using a custom `YAML` file to describe the structure and origin of the data, we should instead use `Metadata Encoding and Transmission
Standard`[METS](https://www.loc.gov/standards/mets/mets-schemadocs.html) and `Preservation Metadata: Implementation
Strategies`[PREMIS](https://www.loc.gov/standards/premis/)

Introduces https://github.com/nlnwa/hermetic/issues/32