### PR TITLE
refactor!: change yaml format of acquisition

### DIFF
--- a/internal/acquisition/acquisition_test.go
+++ b/internal/acquisition/acquisition_test.go
@@ -31,13 +31,20 @@ func TestValidate(t *testing.T) {
 	}
 
 	_, err = acquisitionYamlFile.WriteString(`
-__acquisition_version__: "0.1.0"
-acquisition:
+__acquisition_version__: "0.2.0"
+archive-unit:
     name: "dummy-acquisition"
-    date: "2024-01-03T09:29:16+00:00"
-    original-purpose: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-    acquisition-purpose: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-    access-considerations: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    type: "acquisition"
+    creator: "john doe"
+    description: "Lorem ipsum"
+    copyright-clearance: "Lorem ipsum"
+    access-considerations: "Lorem ipsum"
+    deposit:
+        depositor: "jane doe"
+        date: "2024-01-03T09:29:16+00:00"
+        acquisition-purpose: "Lorem ipsum"
+    handling:
+        author: "jake doe"
 
 files:
     - name: "acquisition.yaml"
@@ -56,10 +63,6 @@ files:
       description: "Dummy file"
       format: "plain"
       path: "dummy.txt"
-
-acquisition-handling:
-    responsible: "nettarkivet"
-    author: "Unknown"
 `)
 
 	if err != nil {


### PR DESCRIPTION
The previous format introduced by commit
bfe0178454b772d8c4c8b54edace6e2518f9e4c0 was a very temporary format, but still can be improved somewhat without reinventing `Metadata Encoding and Transmission
Standard`[METS](https://www.loc.gov/standards/mets/mets-schemadocs.html) and `Preservation Metadata: Implementation
Strategies`[PREMIS](https://www.loc.gov/standards/premis/)

The core change is to rename `Acquisition` to `ArchiveUnit` to reflect what we upload to digital storage better. The type of `ArchiveUnit` is `acquisition`.