### PR TITLE
fix: add sleep to avoid `Teams` webhook throttle

### DIFF
--- a/internal/teams/teams.go
+++ b/internal/teams/teams.go
@@ -9,6 +9,10 @@ import (
 	"github.com/carlmjohnson/requests"
 )
 
+const (
+	avoidMicrosoftTeamsWebhookRateLimit = 1 * time.Second
+)
+
 type Fact struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
@@ -45,6 +49,7 @@ func SendMessage(payload Message, webhookUrl string) error {
 	if err != nil {
 		return fmt.Errorf("failed to send message to teams, cause: `%w`", err)
 	}
+	time.Sleep(avoidMicrosoftTeamsWebhookRateLimit)
 	return nil
 }
 


### PR DESCRIPTION
According to the
[documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet), the `Teams` webhook has the following restrictions:

```
If more than four requests are made in a second, the client connection
is throttled until the window refreshes for the duration of the fixed
rate. A retry logic with exponential backoff can mitigate rate limiting
for cases where requests exceed the limits within a second. To avoid
hitting the rate limits, see HTTP 429 responses.
```

The current send message implementation does not take this into account and just sends messages as fast as it can. To avoid being throttled, we now add a sleep of 1 second every time a message is sent.