### PR TITLE
fix: increase life time of cached objects to 1 week

### DIFF
--- a/internal/send/send.go
+++ b/internal/send/send.go
@@ -141,7 +141,7 @@ func PrepareAndSendSubmissionInformationPackage(kafkaEndpoints []string, transfe
 	}
 	config := bigcache.Config{
 		Shards:      1024,
-		LifeWindow:  24 * time.Hour,
+		LifeWindow:  24 * 7 * time.Hour,
 		CleanWindow: 1 * time.Hour,
 	}
 	cache, err := bigcache.New(context.Background(), config)


### PR DESCRIPTION
# Motivation

Since `Digital Preservation System` (DPS) is sometimes down for maintenance for longer than 24 hours, this triggered re-uploads of the artifacts. This led to a lot of alerts in the `Teams` notification channel.

By increasing the lifetime of those objects to 1 week, we can hopefully avoid this occurring again.

One drawback of this is that more memory will be used by the system running `hermetic-transfer`.