### PR TITLE
Support for listening to confirm-topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ hermetic send \
 ```
 
 ### Verify
-
+#### Reject
 ```shell
 hermetic verify \
     --kafka-endpoints=<list-of-kafka-endpoints> \
-    --reject-topic <topic-name>
+    reject
+      --reject-topic <topic-name>
+```
+#### Confirm
+```shell
+hermetic verify \
+--kafka-endpoints=<list-of-kafka-endpoints> \
+confirm
+--confirm-topic <topic-name>
 ```
 
 ### Acquisition upload

--- a/cmd/verify/confirm/confirm.go
+++ b/cmd/verify/confirm/confirm.go
@@ -1,0 +1,44 @@
+package confirm
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"hermetic/internal/common_flags"
+	"hermetic/internal/teams"
+	confirmImplementation "hermetic/internal/verify/confirm"
+)
+
+func NewCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "confirm",
+		Short: "Continuously report all successfully preserved data",
+		Args:  cobra.NoArgs,
+		RunE:  parseArgumentsAndCallVerify,
+	}
+	confirmTopicFlagName := "confirm-topic"
+	command.Flags().String(confirmTopicFlagName, "", "name of confirm-topic")
+	if err := command.MarkFlagRequired(confirmTopicFlagName); err != nil {
+		panic(fmt.Sprintf("failed to mark flag %s as required, original error: '%s'", confirmTopicFlagName, err))
+	}
+	return command
+}
+
+func parseArgumentsAndCallVerify(cmd *cobra.Command, args []string) error {
+	confirmTopicName, err := cmd.Flags().GetString("confirm-topic")
+	if err != nil {
+		return fmt.Errorf("failed to get confirm-topic flag, cause: `%w`", err)
+	}
+
+	err = confirmImplementation.Verify(confirmTopicName)
+	if err != nil {
+		err = fmt.Errorf("verification error, cause: `%w`", err)
+		fmt.Printf("Sending error message to Teams\n")
+		teamsErrorMessage := teams.CreateGeneralFailureMessage(err)
+		if err := teams.SendMessage(teamsErrorMessage, common_flags.TeamsWebhookNotificationUrl); err != nil {
+			err = fmt.Errorf("failed to send error message to Teams, cause: `%w`", err)
+			fmt.Printf("%s\n", err)
+		}
+		return err
+	}
+	return err
+}

--- a/cmd/verify/reject/reject.go
+++ b/cmd/verify/reject/reject.go
@@ -1,0 +1,44 @@
+package reject
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"hermetic/internal/common_flags"
+	"hermetic/internal/teams"
+	rejectImplementation "hermetic/internal/verify/reject"
+)
+
+func NewCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "reject",
+		Short: "Continuously report all rejected data",
+		Args:  cobra.NoArgs,
+		RunE:  parseArgumentsAndCallVerify,
+	}
+	rejectTopicFlagName := "reject-topic"
+	command.Flags().String(rejectTopicFlagName, "", "name of reject-topic")
+	if err := command.MarkFlagRequired(rejectTopicFlagName); err != nil {
+		panic(fmt.Sprintf("failed to mark flag %s as required, original error: '%s'", rejectTopicFlagName, err))
+	}
+	return command
+}
+
+func parseArgumentsAndCallVerify(cmd *cobra.Command, args []string) error {
+	rejectTopicName, err := cmd.Flags().GetString("reject-topic")
+	if err != nil {
+		return fmt.Errorf("failed to get reject-topic flag, cause: `%w`", err)
+	}
+
+	err = rejectImplementation.Verify(rejectTopicName, common_flags.KafkaEndpoints, common_flags.TeamsWebhookNotificationUrl)
+	if err != nil {
+		err = fmt.Errorf("verification error, cause: `%w`", err)
+		fmt.Printf("Sending error message to Teams\n")
+		teamsErrorMessage := teams.CreateGeneralFailureMessage(err)
+		if err := teams.SendMessage(teamsErrorMessage, common_flags.TeamsWebhookNotificationUrl); err != nil {
+			err = fmt.Errorf("failed to send error message to Teams, cause: `%w`", err)
+			fmt.Printf("%s\n", err)
+		}
+		return err
+	}
+	return err
+}

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -1,47 +1,15 @@
 package verify
 
 import (
-	"fmt"
-	"hermetic/internal/common_flags"
-	"hermetic/internal/teams"
-	verifyImplementation "hermetic/internal/verify"
-
 	"github.com/spf13/cobra"
+	"hermetic/cmd/verify/reject"
 )
 
 func NewCommand() *cobra.Command {
-	command := &cobra.Command{
+	rootCommand := &cobra.Command{
 		Use:   "verify",
 		Short: "Continuously verifies uploaded data responses",
-		Args:  cobra.NoArgs,
-		RunE:  parseArgumentsAndCallVerify,
 	}
-	rejectTopicFlagName := "reject-topic"
-	command.Flags().String(rejectTopicFlagName, "", "name of reject-topic")
-	if err := command.MarkFlagRequired(rejectTopicFlagName); err != nil {
-		panic(fmt.Sprintf("failed to mark flag %s as required, original error: '%s'", rejectTopicFlagName, err))
-	}
-	// TODO(https://github.com/nlnwa/hermetic/issues/3): handle the `confirm`
-	// topic messages
-	return command
-}
-
-func parseArgumentsAndCallVerify(cmd *cobra.Command, args []string) error {
-	rejectTopicName, err := cmd.Flags().GetString("reject-topic")
-	if err != nil {
-		return fmt.Errorf("failed to get reject-topic flag, cause: `%w`", err)
-	}
-
-	err = verifyImplementation.Verify(rejectTopicName, common_flags.KafkaEndpoints, common_flags.TeamsWebhookNotificationUrl)
-	if err != nil {
-		err = fmt.Errorf("verification error, cause: `%w`", err)
-		fmt.Printf("Sending error message to Teams\n")
-		teamsErrorMessage := teams.CreateGeneralFailureMessage(err)
-		if err := teams.SendMessage(teamsErrorMessage, common_flags.TeamsWebhookNotificationUrl); err != nil {
-			err = fmt.Errorf("failed to send error message to Teams, cause: `%w`", err)
-			fmt.Printf("%s\n", err)
-		}
-		return err
-	}
-	return err
+	rootCommand.AddCommand(reject.NewCommand())
+	return rootCommand
 }

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"github.com/spf13/cobra"
+	"hermetic/cmd/verify/confirm"
 	"hermetic/cmd/verify/reject"
 )
 
@@ -11,5 +12,6 @@ func NewCommand() *cobra.Command {
 		Short: "Continuously verifies uploaded data responses",
 	}
 	rootCommand.AddCommand(reject.NewCommand())
+	rootCommand.AddCommand(confirm.NewCommand())
 	return rootCommand
 }

--- a/internal/verify/confirm/confirm.go
+++ b/internal/verify/confirm/confirm.go
@@ -1,0 +1,12 @@
+package confirmImplmentation
+
+import (
+	"fmt"
+)
+
+func Verify(confirmTopicName string) error {
+	fmt.Printf("Reading messages from topic '%s'\n", confirmTopicName)
+	fmt.Printf("This command is not implemented yet\n" +
+		"Aims to solve issue https://github.com/nlnwa/hermetic/issues/3 ")
+	return nil
+}

--- a/internal/verify/confirm/confirm_test.go
+++ b/internal/verify/confirm/confirm_test.go
@@ -1,0 +1,14 @@
+package confirmImplmentation
+
+import (
+	"testing"
+)
+
+func TestVerify(t *testing.T) {
+	t.Run("Verify function test", func(t *testing.T) {
+		err := Verify(("test-topic"))
+		if err != nil {
+			t.Errorf("Verify() returned error: %v", err)
+		}
+	})
+}

--- a/internal/verify/reject/reject.go
+++ b/internal/verify/reject/reject.go
@@ -1,4 +1,4 @@
-package verifyImplementation
+package rejectImplementation
 
 import (
 	"context"

--- a/internal/verify/reject/reject_test.go
+++ b/internal/verify/reject/reject_test.go
@@ -1,4 +1,4 @@
-package verifyImplementation
+package rejectImplementation
 
 import (
 	"testing"

--- a/internal/verify/reject/teams_message.go
+++ b/internal/verify/reject/teams_message.go
@@ -1,4 +1,4 @@
-package verifyImplementation
+package rejectImplementation
 
 import (
 	"fmt"

--- a/internal/verify/reject/teams_message_test.go
+++ b/internal/verify/reject/teams_message_test.go
@@ -1,4 +1,4 @@
-package verifyImplementation
+package rejectImplementation
 
 import (
 	"encoding/json"

--- a/internal/verify/reject/types.go
+++ b/internal/verify/reject/types.go
@@ -1,4 +1,4 @@
-package verifyImplementation
+package rejectImplementation
 
 type check struct {
 	Status  string


### PR DESCRIPTION
This pull request  is meant as a start to resolve #3.
The functionality of the current verify command is transitioned to the 'reject' sub-command, while a MVP implementation of the 'confirm' sub-command is also included.
