### PR TITLE
feat: Add optional flag for sending confirm message to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+*.idea
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/verify/confirm/confirm.go
+++ b/cmd/verify/confirm/confirm.go
@@ -54,11 +54,7 @@ func parseArgumentsAndReadConfirmTopic(cmd *cobra.Command, args []string) error 
 		GroupID: "nettarkivet-hermetic-verify-confirm",
 	})
 
-	if confirmMessageReceiverUrl != "" {
-		err = confirmImplementation.ReadConfirmTopic(ctx, reader, confirmMessageReceiverUrl)
-	} else {
-		err = confirmImplementation.ReadConfirmTopic(ctx, reader)
-	}
+	err = confirmImplementation.ReadConfirmTopic(ctx, reader, confirmMessageReceiverUrl)
 	if err != nil {
 		err = fmt.Errorf("verification error, cause: `%w`", err)
 		fmt.Printf("Sending error message to Teams\n")

--- a/cmd/verify/confirm/confirm.go
+++ b/cmd/verify/confirm/confirm.go
@@ -12,6 +12,11 @@ import (
 	"os/signal"
 )
 
+const (
+	confirmTopicFlagName           string = "confirm-topic"
+	confirmMessageReceiverFlagName string = "confirm-message-receiver"
+)
+
 func NewCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "confirm",
@@ -19,18 +24,25 @@ func NewCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  parseArgumentsAndReadConfirmTopic,
 	}
-	confirmTopicFlagName := "confirm-topic"
 	command.Flags().String(confirmTopicFlagName, "", "name of confirm-topic")
 	if err := command.MarkFlagRequired(confirmTopicFlagName); err != nil {
 		panic(fmt.Sprintf("failed to mark flag %s as required, original error: '%s'", confirmTopicFlagName, err))
 	}
+
+	command.Flags().String(confirmMessageReceiverFlagName, "", "optional URL for confirm message receiver")
+
 	return command
 }
 
 func parseArgumentsAndReadConfirmTopic(cmd *cobra.Command, args []string) error {
-	confirmTopicName, err := cmd.Flags().GetString("confirm-topic")
+	confirmTopicName, err := cmd.Flags().GetString(confirmTopicFlagName)
 	if err != nil {
 		return fmt.Errorf("failed to get confirm-topic flag, cause: `%w`", err)
+	}
+
+	confirmMessageReceiverUrl, err := cmd.Flags().GetString(confirmMessageReceiverFlagName)
+	if err != nil {
+		return fmt.Errorf("failed to get confirm-message-receiver flag, cause: `%w`", err)
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -42,7 +54,11 @@ func parseArgumentsAndReadConfirmTopic(cmd *cobra.Command, args []string) error 
 		GroupID: "nettarkivet-hermetic-verify-confirm",
 	})
 
-	err = confirmImplementation.ReadConfirmTopic(ctx, reader)
+	if confirmMessageReceiverUrl != "" {
+		err = confirmImplementation.ReadConfirmTopic(ctx, reader, confirmMessageReceiverUrl)
+	} else {
+		err = confirmImplementation.ReadConfirmTopic(ctx, reader)
+	}
 	if err != nil {
 		err = fmt.Errorf("verification error, cause: `%w`", err)
 		fmt.Printf("Sending error message to Teams\n")

--- a/internal/verify/confirm/confirm.go
+++ b/internal/verify/confirm/confirm.go
@@ -1,18 +1,64 @@
 package confirmImplmentation
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/segmentio/kafka-go"
 	"hermetic/internal/dps"
+	"net/http"
+	"net/url"
+	"time"
 )
 
-func ReadConfirmTopic(ctx context.Context, reader *kafka.Reader) error {
+func ReadConfirmTopic(ctx context.Context, reader *kafka.Reader, receiverUrl ...string) error {
 	for {
 		response, err := dps.ReadMessages(ctx, reader)
 		if err != nil {
 			return fmt.Errorf("failed to read message from confirm-topic: `%w`", err)
 		}
-		fmt.Printf("SIP successfully preserved: %+v\n", response)
+		if len(receiverUrl) > 0 {
+			err = SendConfirmMessage(receiverUrl[0], response.DPSResponse)
+			if err != nil {
+				return fmt.Errorf("failed to send confirm message: `%w`", err)
+			}
+		} else {
+			fmt.Printf("Received message: %v\n", response.DPSResponse)
+		}
 	}
+}
+
+func SendConfirmMessage(baseUrl string, response dps.DigitalPreservationSystemResponse) error {
+	url, err := url.JoinPath(baseUrl, response.Identifier)
+	if err != nil {
+		return fmt.Errorf("failed to join URL path: `%w`", err)
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("failed to marshal DPS response to JSON: `%w`", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: `%w`", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send HTTP request: `%w`", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	fmt.Printf("Successfully sent confirm message to %s\n", url)
+	return nil
 }

--- a/internal/verify/confirm/confirm.go
+++ b/internal/verify/confirm/confirm.go
@@ -7,19 +7,20 @@ import (
 	"fmt"
 	"github.com/segmentio/kafka-go"
 	"hermetic/internal/dps"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
 )
 
-func ReadConfirmTopic(ctx context.Context, reader *kafka.Reader, receiverUrl ...string) error {
+func ReadConfirmTopic(ctx context.Context, reader *kafka.Reader, receiverUrl string) error {
 	for {
 		response, err := dps.ReadMessages(ctx, reader)
 		if err != nil {
 			return fmt.Errorf("failed to read message from confirm-topic: `%w`", err)
 		}
 		if len(receiverUrl) > 0 {
-			err = SendConfirmMessage(receiverUrl[0], response.DPSResponse)
+			err = SendConfirmMessage(receiverUrl, response.DPSResponse)
 			if err != nil {
 				return fmt.Errorf("failed to send confirm message: `%w`", err)
 			}
@@ -30,6 +31,7 @@ func ReadConfirmTopic(ctx context.Context, reader *kafka.Reader, receiverUrl ...
 }
 
 func SendConfirmMessage(baseUrl string, response dps.DigitalPreservationSystemResponse) error {
+	slog.Info("Sending confirm message to receiver", "receiver_url", baseUrl)
 	url, err := url.JoinPath(baseUrl, response.Identifier)
 	if err != nil {
 		return fmt.Errorf("failed to join URL path: `%w`", err)


### PR DESCRIPTION
When hermetic recevies a confirm message, we want to relay the response from DPS to update a database with the files location in DPS.